### PR TITLE
feat: 블로그 정렬 기능 및 조회수 시스템 구현

### DIFF
--- a/src/app/posts/[postId]/page.tsx
+++ b/src/app/posts/[postId]/page.tsx
@@ -14,6 +14,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import ShareButton from '../../../components/blog/ShareButton';
 import { getPostMetadata } from '../../../lib/metadata';
+import ViewCounter from '../../../components/blog/ViewCounter';
 
 interface PostDetailPageProps {
   params: Promise<{ postId: string }>;
@@ -63,6 +64,7 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
 
     return (
       <Container size="md" className="py-4">
+        <ViewCounter postId={postId} />
         <article itemScope itemType="https://schema.org/BlogPosting">
           <header className="mb-8">
             <nav aria-label="breadcrumb" className="mb-4 text-sm text-gray-500">

--- a/src/components/blog/CategorySidebar.tsx
+++ b/src/components/blog/CategorySidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { Category } from '../../types';
 
 interface CategorySidebarProps {
@@ -14,12 +15,23 @@ export default function CategorySidebar({
   categories = [],
   totalPostCount = 0,
 }: CategorySidebarProps) {
-  // URL 생성 함수
+  const searchParams = useSearchParams();
+
+  // URL 생성 함수 - 현재 정렬 상태 유지
   const getCategoryUrl = (categoryId?: number) => {
+    const params = new URLSearchParams(searchParams);
+
     if (!categoryId) {
-      return '/';
+      params.delete('category');
+    } else {
+      params.set('category', categoryId.toString());
     }
-    return `/?category=${categoryId}`;
+
+    // 페이지는 1로 리셋
+    params.set('page', '1');
+
+    const queryString = params.toString();
+    return queryString ? `/?${queryString}` : '/';
   };
 
   // 실제 전체 글 개수 계산 (모든 카테고리의 postCount 합산)

--- a/src/components/blog/PostItem.tsx
+++ b/src/components/blog/PostItem.tsx
@@ -36,12 +36,15 @@ export default function PostItem({ post, categories }: PostItemProps) {
 
         <p className="text-gray-600 mb-4">{post.summary}</p>
 
-        <Link
-          href={`/posts/${post.id}`}
-          className="text-blue-600 hover:text-blue-800 transition-colors"
-        >
-          더 읽기
-        </Link>
+        <div className="flex justify-between items-center">
+          <Link
+            href={`/posts/${post.id}`}
+            className="text-blue-600 hover:text-blue-800 transition-colors"
+          >
+            더 읽기
+          </Link>
+          <span className="text-sm text-gray-500">{post.views?.toLocaleString() || 0} 읽음</span>
+        </div>
       </article>
     </Card>
   );

--- a/src/components/blog/PostList.tsx
+++ b/src/components/blog/PostList.tsx
@@ -11,6 +11,7 @@ interface PostListProps {
   totalPages: number;
   categories: Category[];
   baseUrl?: string;
+  onPageChange?: (page: number) => void;
 }
 
 export default function PostList({
@@ -19,6 +20,7 @@ export default function PostList({
   totalPages,
   categories,
   baseUrl = '/',
+  onPageChange,
 }: PostListProps) {
   return (
     <div className="max-w-3xl">
@@ -28,7 +30,12 @@ export default function PostList({
             <PostItem key={post.id} post={post} categories={categories} />
           ))}
 
-          <Pagination currentPage={currentPage} totalPages={totalPages} baseUrl={baseUrl} />
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            baseUrl={baseUrl}
+            onPageChange={onPageChange}
+          />
         </>
       ) : (
         <div className="text-center py-20">

--- a/src/components/blog/SortButton.tsx
+++ b/src/components/blog/SortButton.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { SortOption } from '../../types';
+
+interface SortButtonProps {
+  currentSort: SortOption;
+  onSortChange: (sort: SortOption) => void;
+  className?: string;
+}
+
+const SORT_OPTIONS = [
+  {
+    value: 'createdAt,desc' as SortOption,
+    label: '최신',
+    isDesc: true,
+  },
+  {
+    value: 'createdAt,asc' as SortOption,
+    label: '최신',
+    isDesc: false,
+  },
+  {
+    value: 'views,desc' as SortOption,
+    label: '조회수',
+    isDesc: true,
+  },
+  {
+    value: 'views,asc' as SortOption,
+    label: '조회수',
+    isDesc: false,
+  },
+];
+
+const SortButton = ({ currentSort, onSortChange, className = '' }: SortButtonProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const currentOption =
+    SORT_OPTIONS.find(option => option.value === currentSort) || SORT_OPTIONS[0];
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSortSelect = (sortOption: SortOption) => {
+    onSortChange(sortOption);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={`relative ${className}`} ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+      >
+        <div className="flex items-center gap-1">
+          <span>{currentOption.label}</span>
+          <span className="text-gray-500">{currentOption.isDesc ? '↓' : '↑'}</span>
+        </div>
+        <svg
+          className={`w-3.5 h-3.5 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full right-0 mt-2 w-28 bg-white border border-gray-200 rounded-lg shadow-lg z-10">
+          {SORT_OPTIONS.map(option => (
+            <button
+              key={option.value}
+              onClick={() => handleSortSelect(option.value)}
+              className={`w-full px-3 py-1.5 text-left text-sm hover:bg-gray-50 focus:outline-none focus:bg-gray-50 transition-colors flex items-center gap-1 ${
+                option.value === currentSort ? 'bg-blue-50 text-blue-700' : 'text-gray-700'
+              } ${SORT_OPTIONS.indexOf(option) === 0 ? 'rounded-t-lg' : ''} ${SORT_OPTIONS.indexOf(option) === SORT_OPTIONS.length - 1 ? 'rounded-b-lg' : ''}`}
+            >
+              <span>{option.label}</span>
+              <span className="text-gray-500">{option.isDesc ? '↓' : '↑'}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SortButton;

--- a/src/components/blog/ViewCounter.tsx
+++ b/src/components/blog/ViewCounter.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+import { api } from '../../lib/api/index';
+
+interface ViewCounterProps {
+  postId: string;
+}
+
+const ViewCounter = ({ postId }: ViewCounterProps) => {
+  useEffect(() => {
+    const incrementViews = async () => {
+      try {
+        await api.posts.incrementViews(parseInt(postId, 10));
+      } catch (error) {
+        console.error('조회수 증가 실패:', error);
+      }
+    };
+
+    incrementViews();
+  }, [postId]);
+
+  return null;
+};
+
+export default ViewCounter;

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { api } from '../../lib/api/index';
+import Container from '../ui/Container';
+import HeroSection from '../sections/HeroSection';
+import BlogSection from '../sections/BlogSection';
+import Divider from '../ui/Divider';
+import SortButton from '../blog/SortButton';
+import { PostListResponse, Category, SortOption } from '../../types';
+import ErrorMessage from '../ui/feedback/ErrorMessage';
+import Loading from '../ui/feedback/Loading';
+
+interface HomePageProps {
+  initialPosts: PostListResponse;
+  initialCategories: Category[];
+  initialPage: number;
+  initialCategory?: number;
+}
+
+const HomePage = ({
+  initialPosts,
+  initialCategories,
+  initialPage,
+  initialCategory,
+}: HomePageProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [posts, setPosts] = useState<PostListResponse>(initialPosts);
+  const [categories] = useState<Category[]>(initialCategories);
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const [selectedCategory, setSelectedCategory] = useState<number | undefined>(initialCategory);
+  const [currentSort, setCurrentSort] = useState<SortOption>('createdAt,desc');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchPosts = async (
+    page: number,
+    category?: number,
+    sort: SortOption = 'createdAt,desc'
+  ) => {
+    setIsLoading(true);
+    try {
+      const postsData = await api.posts.getList(page - 1, 5, category, sort);
+      setPosts(postsData);
+    } catch (error) {
+      console.error('게시글 로딩 오류:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSortChange = (sort: SortOption) => {
+    setCurrentSort(sort);
+
+    const params = new URLSearchParams(searchParams);
+    if (selectedCategory) {
+      params.set('category', selectedCategory.toString());
+    } else {
+      params.delete('category');
+    }
+    params.set('page', '1');
+    params.set('sort', sort);
+
+    router.push(`/?${params.toString()}`);
+    fetchPosts(1, selectedCategory, sort);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    const params = new URLSearchParams(searchParams);
+    if (selectedCategory) {
+      params.set('category', selectedCategory.toString());
+    } else {
+      params.delete('category');
+    }
+    params.set('page', page.toString());
+    params.set('sort', currentSort);
+
+    router.push(`/?${params.toString()}`);
+    fetchPosts(page, selectedCategory, currentSort);
+    setCurrentPage(page);
+  };
+
+  useEffect(() => {
+    const sortParam = searchParams.get('sort') as SortOption;
+    const categoryParam = searchParams.get('category');
+    const pageParam = searchParams.get('page');
+
+    if (
+      sortParam &&
+      ['createdAt,desc', 'createdAt,asc', 'views,desc', 'views,asc'].includes(sortParam)
+    ) {
+      setCurrentSort(sortParam);
+    }
+
+    const newCategory = categoryParam ? parseInt(categoryParam, 10) : undefined;
+    const newPage = pageParam ? parseInt(pageParam, 10) : 1;
+
+    if (newCategory !== selectedCategory || newPage !== currentPage) {
+      setSelectedCategory(newCategory);
+      setCurrentPage(newPage);
+      fetchPosts(newPage, newCategory, currentSort);
+    }
+  }, [searchParams]);
+
+  if (isLoading) {
+    return (
+      <Container size="md">
+        <Loading />
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="md">
+      <HeroSection
+        title="안녕하세요, SIKU(시쿠)입니다."
+        subtitle={`건국대학교 컴퓨터공학부 4학년 재학중이며,\n서버 개발을 공부하며 다양한 경험과 배움을 포스팅에 기록하고 있습니다.`}
+        imageSrc="/profile.jpg"
+      />
+
+      <Divider variant="border" />
+
+      <div className="py-8">
+        <div className="flex justify-between items-center mb-6">
+          <h2 className="text-2xl font-bold">최근 게시글</h2>
+          <SortButton
+            currentSort={currentSort}
+            onSortChange={handleSortChange}
+            className="ml-auto"
+          />
+        </div>
+
+        <BlogSection
+          posts={posts}
+          categories={categories}
+          selectedCategory={selectedCategory}
+          onPageChange={handlePageChange}
+        />
+      </div>
+    </Container>
+  );
+};
+
+export default HomePage;

--- a/src/components/sections/BlogSection.tsx
+++ b/src/components/sections/BlogSection.tsx
@@ -16,6 +16,7 @@ interface BlogSectionProps {
   categories?: Category[];
   selectedCategory?: number;
   className?: string;
+  onPageChange?: (page: number) => void;
 }
 
 export default function BlogSection({
@@ -23,6 +24,7 @@ export default function BlogSection({
   categories,
   selectedCategory,
   className = '',
+  onPageChange,
 }: BlogSectionProps) {
   // 데이터가 없는 경우 오류 메시지 표시
   if (!posts || !categories) {
@@ -47,6 +49,7 @@ export default function BlogSection({
             currentPage={currentPage}
             totalPages={totalPages}
             categories={categories}
+            onPageChange={onPageChange}
           />
         </main>
 

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -27,8 +27,12 @@ export default function HeroSection({
         {/* 자기소개 */}
         <div className="flex flex-col space-y-6 text-center md:text-left">
           <div>
-            <h1 className="text-3xl md:text-4xl font-bold mb-4">{title}</h1>
-            <p className="text-xl text-gray-600 whitespace-pre-line">{subtitle}</p>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 whitespace-nowrap">
+              {title}
+            </h1>
+            <p className="text-lg md:text-xl text-gray-600 whitespace-pre-line leading-relaxed">
+              {subtitle}
+            </p>
 
             <div className="flex flex-wrap gap-4 mt-6 justify-center md:justify-start">
               <Link

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -8,6 +8,7 @@ interface PaginationProps {
   totalPages: number;
   baseUrl: string;
   className?: string;
+  onPageChange?: (page: number) => void;
 }
 
 export default function Pagination({
@@ -15,6 +16,7 @@ export default function Pagination({
   totalPages,
   baseUrl,
   className = '',
+  onPageChange,
 }: PaginationProps) {
   // 페이지가 한 페이지뿐이면 페이지네이션을 표시하지 않음
   if (totalPages <= 1) {
@@ -57,73 +59,126 @@ export default function Pagination({
 
   const pageNumbers = generatePageNumbers();
 
+  const handlePageClick = (page: number, e: React.MouseEvent) => {
+    if (onPageChange) {
+      e.preventDefault();
+      onPageChange(page);
+    }
+  };
+
   return (
     <nav className={`flex justify-center mt-12 ${className}`} aria-label="페이지 네비게이션">
       <div className="flex items-center space-x-2">
         {/* 이전 페이지 버튼 */}
-        <Link
-          href={getPageUrl(currentPage - 1)}
-          className={`inline-flex items-center justify-center w-10 h-10 rounded-lg border transition-all duration-200 ${
-            currentPage === 1
-              ? 'border-gray-200 text-gray-300 cursor-not-allowed'
-              : 'border-gray-200 text-gray-600 hover:text-black hover:border-black hover:bg-gray-50'
-          }`}
-          aria-disabled={currentPage === 1}
-          tabIndex={currentPage === 1 ? -1 : 0}
-          onClick={e => {
-            if (currentPage === 1) {
-              e.preventDefault();
-            }
-          }}
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 19l-7-7 7-7"
-            />
-          </svg>
-        </Link>
+        {currentPage === 1 ? (
+          <span
+            className="inline-flex items-center justify-center w-10 h-10 rounded-lg border transition-all duration-200 border-gray-200 text-gray-300 cursor-not-allowed"
+            aria-disabled={true}
+            tabIndex={-1}
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </span>
+        ) : onPageChange ? (
+          <button
+            onClick={(e: React.MouseEvent) => handlePageClick(currentPage - 1, e)}
+            className="inline-flex items-center justify-center w-10 h-10 rounded-lg border transition-all duration-200 border-gray-200 text-gray-600 hover:text-black hover:border-black hover:bg-gray-50"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+        ) : (
+          <Link
+            href={getPageUrl(currentPage - 1)}
+            className="inline-flex items-center justify-center w-10 h-10 rounded-lg border transition-all duration-200 border-gray-200 text-gray-600 hover:text-black hover:border-black hover:bg-gray-50"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </Link>
+        )}
 
         {/* 페이지 번호 버튼들 */}
         <div className="flex items-center space-x-1">
-          {pageNumbers.map(page => (
-            <Link
-              key={page}
-              href={getPageUrl(page)}
-              className={`inline-flex items-center justify-center w-10 h-10 rounded-lg border text-sm font-medium transition-all duration-200 ${
-                page === currentPage
-                  ? 'bg-black text-white border-black'
-                  : 'border-gray-200 text-gray-700 hover:text-black hover:border-black hover:bg-gray-50'
-              }`}
-              aria-current={page === currentPage ? 'page' : undefined}
-            >
-              {page}
-            </Link>
-          ))}
+          {pageNumbers.map(page => {
+            return onPageChange ? (
+              <button
+                key={page}
+                className={`inline-flex items-center justify-center w-10 h-10 rounded-lg border text-sm font-medium transition-all duration-200 ${
+                  page === currentPage
+                    ? 'bg-black text-white border-black'
+                    : 'border-gray-200 text-gray-700 hover:text-black hover:border-black hover:bg-gray-50'
+                }`}
+                aria-current={page === currentPage ? 'page' : undefined}
+                onClick={(e: React.MouseEvent) => handlePageClick(page, e)}
+              >
+                {page}
+              </button>
+            ) : (
+              <Link
+                key={page}
+                href={getPageUrl(page)}
+                className={`inline-flex items-center justify-center w-10 h-10 rounded-lg border text-sm font-medium transition-all duration-200 ${
+                  page === currentPage
+                    ? 'bg-black text-white border-black'
+                    : 'border-gray-200 text-gray-700 hover:text-black hover:border-black hover:bg-gray-50'
+                }`}
+                aria-current={page === currentPage ? 'page' : undefined}
+                onClick={(e: React.MouseEvent) => handlePageClick(page, e)}
+              >
+                {page}
+              </Link>
+            );
+          })}
         </div>
 
         {/* 다음 페이지 버튼 */}
-        <Link
-          href={getPageUrl(currentPage + 1)}
-          className={`inline-flex items-center justify-center w-10 h-10 rounded-lg border transition-all duration-200 ${
-            currentPage === totalPages
-              ? 'border-gray-200 text-gray-300 cursor-not-allowed'
-              : 'border-gray-200 text-gray-600 hover:text-black hover:border-black hover:bg-gray-50'
-          }`}
-          aria-disabled={currentPage === totalPages}
-          tabIndex={currentPage === totalPages ? -1 : 0}
-          onClick={e => {
-            if (currentPage === totalPages) {
-              e.preventDefault();
-            }
-          }}
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-          </svg>
-        </Link>
+        {currentPage === totalPages ? (
+          <span
+            className="inline-flex items-center justify-center w-10 h-10 rounded-lg border transition-all duration-200 border-gray-200 text-gray-300 cursor-not-allowed"
+            aria-disabled={true}
+            tabIndex={-1}
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </span>
+        ) : onPageChange ? (
+          <button
+            onClick={(e: React.MouseEvent) => handlePageClick(currentPage + 1, e)}
+            className="inline-flex items-center justify-center w-10 h-10 rounded-lg border transition-all duration-200 border-gray-200 text-gray-600 hover:text-black hover:border-black hover:bg-gray-50"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        ) : (
+          <Link
+            href={getPageUrl(currentPage + 1)}
+            className="inline-flex items-center justify-center w-10 h-10 rounded-lg border transition-all duration-200 border-gray-200 text-gray-600 hover:text-black hover:border-black hover:bg-gray-50"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
+        )}
       </div>
     </nav>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -87,6 +87,30 @@ export async function putData<T, D = any>(
 }
 
 /**
+ * PATCH 요청 래퍼 함수
+ * @param url 엔드포인트
+ * @param data 요청 데이터
+ * @param config axios 요청 설정
+ * @returns 응답 데이터
+ */
+export async function patchData<T, D = any>(
+  url: string,
+  data?: D,
+  config?: AxiosRequestConfig
+): Promise<T> {
+  try {
+    const response = await api.patch<ApiResponse<T>>(url, data, config);
+    return response.data.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const apiError = error.response.data as ApiResponse<null>;
+      throw new Error(apiError.error?.message || '요청 처리 중 오류가 발생했습니다.');
+    }
+    throw error;
+  }
+}
+
+/**
  * DELETE 요청 래퍼 함수
  * @param url 엔드포인트
  * @param config axios 요청 설정

--- a/src/lib/api/posts.ts
+++ b/src/lib/api/posts.ts
@@ -86,6 +86,19 @@ export class PostsService {
     }
   }
 
+  async incrementViews(postId: number): Promise<void> {
+    try {
+      console.log('게시물 조회수 증가 요청:', { postId });
+      await this.client.request<void>({
+        url: `${API_ENDPOINTS.POSTS}/${postId}/views`,
+        method: 'PATCH',
+      });
+      console.log('게시물 조회수 증가 완료:', { postId });
+    } catch (error) {
+      console.error('게시물 조회수 증가 오류:', error);
+    }
+  }
+
   async delete(postId: number): Promise<string> {
     try {
       console.log('게시물 삭제 요청:', { postId });

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -90,7 +90,6 @@ export function getCategoryMetadata(categoryName: string): Metadata {
   };
 }
 
-
 // 블로그 포스트 메타데이터 생성 함수
 export function getPostMetadata(
   title: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Post {
   categoryId: number;
   createdAt: string;
   updatedAt: string;
+  views: number;
 }
 
 export interface PostSummary {
@@ -16,6 +17,7 @@ export interface PostSummary {
   categoryId: number;
   createdAt: string;
   updatedAt: string;
+  views: number;
 }
 
 // 카테고리 관련 타입
@@ -110,4 +112,13 @@ export type GetCategoriesResponse = APIResponse<Category[]>;
 export interface UploadImageResponse {
   url: string;
   size: number; // API Spec 에서는 int64지만, JavaScript 에서는 number 로 충분
+}
+
+// 정렬 관련 타입
+export type SortOption = 'createdAt,desc' | 'createdAt,asc' | 'views,desc' | 'views,asc';
+
+export interface SortOptionInfo {
+  value: SortOption;
+  label: string;
+  description: string;
 }


### PR DESCRIPTION
- 게시글 조회수 증가 API 연동 (ViewCounter 컴포넌트)
- 드롭다운 방식의 정렬 UI 구현 (최신순/조회수순, 오름차순/내림차순)
- 페이지네이션에서 정렬 상태 유지 기능
- 카테고리 변경 시 정렬 옵션 유지
- 게시글 목록에 조회수 표시
- 모바일 반응형 UI 최적화
- SSR과 클라이언트 사이드 상태 동기화

🤖 Generated with [Claude Code](https://claude.ai/code)