### PR TITLE
feat: robots.txt 및 사이트맵 최적화 (SEO 개선)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,23 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Allow: /
+Allow: /posts/
+
+# Admin과 API는 검색엔진 접근 차단
 Disallow: /admin/
 Disallow: /api/
+Disallow: /login
+
+# 크롤러별 최적화
+User-agent: Googlebot
+Allow: /
+Allow: /posts/
+Disallow: /admin/
+Disallow: /api/
+Disallow: /login
+
+# 크롤 속도 제한 (서버 부하 방지)
+Crawl-delay: 1
 
 # Host
 Host: https://bumsiku.kr


### PR DESCRIPTION
- robots.txt 파일에 검색 엔진 접근 제어를 추가하여 admin 및 API 경로 차단
- 사이트맵의 revalidate 시간을 1시간으로 조정하여 SEO 최적화
- 포스트 URL의 동적 우선순위 및 변경 빈도 계산 로직 개선
- API 호출 실패 시 기본 페이지 포함하여 SEO 최적화된 fallback 제공